### PR TITLE
Push branch and git tag separately in ECRPush

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,5 @@
     "constructs": {
       "optional": true
     }
-  },
-  "scripts": {
-    "build": "yarn install; npx tsc -p src/tsconfig.json --outDir dist; cp -r dist/*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "constructs": {
       "optional": true
     }
+  },
+  "scripts": {
+    "build": "npx tsc -p src/tsconfig.json --outDir ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     }
   },
   "scripts": {
-    "build": "npx tsc -p src/tsconfig.json --outDir ."
+    "build": "yarn install; npx tsc -p src/tsconfig.json --outDir dist; cp -r dist/*"
   }
 }

--- a/src/ecrPush.ts
+++ b/src/ecrPush.ts
@@ -44,7 +44,24 @@ export default async ({
 
   if (tagWithGitHash) {
     const hashTag = await gitHash(gitRepoPath, { gitUpToDate: true })
-    // Put hashTag first to ensure if latest is added, then the git hash is already ther
+    const { exitCode } = await execFile(
+      'docker',
+      ['manifest', 'inspect', `${repo}:${hashTag}`],
+      {
+        env: {
+          ...process.env,
+          ...awsEnv,
+        },
+        okExitCodes: [0, 1],
+      },
+    )
+    if (exitCode === 0) {
+      log(`There is already an image with git hashtag: ${highlight(
+        `${repo}:${hashTag}`,
+      )}`,
+      )
+    }
+    // Put hashTag first to ensure if latest is added, then the git hash is already there
     tags.splice(0, 0, hashTag)
   }
 

--- a/src/gitBranch.ts
+++ b/src/gitBranch.ts
@@ -14,15 +14,14 @@ export default async (
       pluginName: '@mindhive/deploy/gitHash',
     })
   }
-  const { stdOut: hashOut } = await execFile(
+  const { stdOut: branchOut } = await execFile(
     'git',
-    ['rev-parse', '--short', 'HEAD'],
+    ['rev-parse', '--abbrev-ref', 'HEAD'],
     {
       cwd: repoPath,
       captureOutput: true,
     },
   )
-  const parts = ['git', hashOut.trim()]
 
-  return parts.join('-')
+  return branchOut.trim()
 }

--- a/src/gitBranch.ts
+++ b/src/gitBranch.ts
@@ -11,7 +11,7 @@ export default async (
 ): Promise<string> => {
   if (gitUpToDate) {
     await ensureGitUpToDate(repoPath, {
-      pluginName: '@mindhive/deploy/gitHash',
+      pluginName: '@mindhive/deploy/gitBranch',
     })
   }
   const { stdOut: branchOut } = await execFile(

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "moduleResolution": "Node16"
+    "declaration": true
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "moduleResolution": "Node16"
   }
 }


### PR DESCRIPTION
Changes to tagging of pushed docker images to enable e2e testing in CI from docker images.

### Current

```
branch = master
remoteImageTag = None (default=latest)
tags = [git-12345, latest]

branch = test-branch
remoteImageTag = None (default=latest)
tags = [git-12345-test-branch, latest]

branch = test-branch
remoteImageTag = ci
tags = [ci-git-12345-test-branch, ci]

If git tag exists, do not push.
```

### Proposed

```
branch = master
remoteImageTag = None (default=latest)
tags = [git-12345, latest]

branch = test-branch
remoteImageTag = None (default=latest)
tags = [git-12345, test-branch]

branch = test-branch
remoteImageTag = None (default=latest)
tags = [git-12345, test-branch]

branch = test-branch
remoteImageTag = ci
tags = [git-12345, test-branch, ci]

If git tag exists, still push.
```