### PR TITLE
Run mhd without aws-vault when using CI

### DIFF
--- a/script/mhd
+++ b/script/mhd
@@ -21,13 +21,12 @@ fi
 if [[ $gulp_args =~ ^open:.* ]]; then
   vault_opts="--duration=1h"
 fi
-# shellcheck disable=SC2086
-TS_NODE_TRANSPILE_ONLY=true
-MHD_ARGS="$mhd_args"
 
 if [ "$CI" = "true" ]; then
-  node_modules/.bin/gulp $gulp_args
+  # shellcheck disable=SC2086
+  TS_NODE_TRANSPILE_ONLY=true MHD_ARGS="$mhd_args" node_modules/.bin/gulp $gulp_args
 else
-  aws-vault exec $vault_opts mindhive-ops -- \
+  # shellcheck disable=SC2086
+  TS_NODE_TRANSPILE_ONLY=true MHD_ARGS="$mhd_args" aws-vault exec $vault_opts mindhive-ops -- \
     node_modules/.bin/gulp $gulp_args
 fi

--- a/script/mhd
+++ b/script/mhd
@@ -5,7 +5,7 @@
 set -e
 ancestor_dir=$(git rev-parse --show-toplevel)
 project_dir=${ancestor_dir%%-control}
-cd "${project_dir}/deploy" > /dev/null
+cd "${project_dir}/deploy" >/dev/null
 vault_opts=""
 mhd_args=""
 if [[ $# == 0 ]]; then
@@ -22,6 +22,12 @@ if [[ $gulp_args =~ ^open:.* ]]; then
   vault_opts="--duration=1h"
 fi
 # shellcheck disable=SC2086
-TS_NODE_TRANSPILE_ONLY=true MHD_ARGS="$mhd_args" \
-  aws-vault exec $vault_opts mindhive-ops -- \
+TS_NODE_TRANSPILE_ONLY=true
+MHD_ARGS="$mhd_args"
+
+if [ "$CI" = "true" ]; then
   node_modules/.bin/gulp $gulp_args
+else
+  aws-vault exec $vault_opts mindhive-ops -- \
+    node_modules/.bin/gulp $gulp_args
+fi


### PR DESCRIPTION
Make the interface between CI and local similar by allowing mhd without aws-vault

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables