### PR TITLE
Add profileName and roleName as args to addAwsVaultProfile

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -40,6 +40,7 @@ mv package.json dist/
 if git show-ref --verify --quiet refs/remotes/origin/$release_branch; then
   echo "Checking out existing $release_branch."
   git checkout $release_branch
+  git pull origin
 else
   echo "Creating and checking out $release_branch from release."
   git fetch origin release/master:release/master

--- a/src/internal/addAwsVaultProfile.ts
+++ b/src/internal/addAwsVaultProfile.ts
@@ -27,6 +27,7 @@ const existingConfigContent = () => {
 }
 
 export default (options: IOptions) => async () => {
+  log(`Adding profile for ${options.profileName}`)
   const { profileName, header, iniProfile } = await awsVaultProfile(options)
   const config = existingConfigContent()
   if (config.includes(header)) {

--- a/src/internal/addAwsVaultProfile.ts
+++ b/src/internal/addAwsVaultProfile.ts
@@ -27,7 +27,6 @@ const existingConfigContent = () => {
 }
 
 export default (options: IOptions) => async () => {
-  log(`Adding profile for ${options.profileName}`)
   const { profileName, header, iniProfile } = await awsVaultProfile(options)
   const config = existingConfigContent()
   if (config.includes(header)) {

--- a/src/internal/awsVaultProfile.ts
+++ b/src/internal/awsVaultProfile.ts
@@ -18,6 +18,7 @@ export interface IOptions {
   region?: string
   roleName: string
   devName?: string
+  profileName?: string
 }
 
 export const awsVaultProfile = async ({
@@ -26,14 +27,21 @@ export const awsVaultProfile = async ({
   region,
   roleName,
   devName,
+  profileName,
 }: IOptions): Promise<IResult> => {
-  const profileNameParts =
-    stage === 'dev' ? [stage] : stage === 'production' ? [proj] : [proj, stage]
-  if (roleName) {
-    profileNameParts.push(roleName)
+
+  let actualProfileName = profileName
+
+  if(!profileName){
+    const profileNameParts =
+      stage === 'dev' ? [stage] : stage === 'production' ? [proj] : [proj, stage]
+    if (roleName) {
+      profileNameParts.push(roleName)
+    }
+    actualProfileName = profileNameParts.join('-')
   }
-  const profileName = profileNameParts.join('-')
-  const header = `[profile ${profileName}]`
+  
+  const header = `[profile ${actualProfileName}]`
   const account = await resolveAccount({ proj, stage, devName })
   const iniProfile = [
     header,
@@ -49,7 +57,7 @@ export const awsVaultProfile = async ({
     iniProfile.push(`region = ${region}`)
   }
   return {
-    profileName,
+    profileName: actualProfileName,
     header,
     iniProfile: iniProfile.join('\n'),
   }

--- a/src/internal/awsVaultProfile.ts
+++ b/src/internal/awsVaultProfile.ts
@@ -30,7 +30,7 @@ export const awsVaultProfile = async ({
   profileName,
 }: IOptions): Promise<IResult> => {
 
-  let actualProfileName = profileName
+  let actualProfileName: string
 
   if(!profileName){
     const profileNameParts =
@@ -39,6 +39,8 @@ export const awsVaultProfile = async ({
       profileNameParts.push(roleName)
     }
     actualProfileName = profileNameParts.join('-')
+  } else {
+    actualProfileName = profileName
   }
   
   const header = `[profile ${actualProfileName}]`

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -57,8 +57,7 @@ export default ({ proj, stages, region }: IOptions) => {
             type: 'string',
           })
         )
-
-        addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName }),
+        addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
       }
     )
   }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -22,17 +22,20 @@ export default ({ proj, stages, region }: IOptions) => {
   stages.forEach((stage) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(
-      `add:aws-vault:${stage}`, () => {
-          const args = parseArgs(
-            globalArgs
-              .option('profile-name', {
-                type: 'string',
-              })
-          )
-          addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
-        }
-    )
+    task(`add:aws-vault:${stage}`, async () => {
+      const args = parseArgs(
+        globalArgs.option('profile-name', {
+          type: 'string',
+        }),
+      )
+      addAwsVaultProfile({
+        proj,
+        stage,
+        region,
+        roleName: userRoleName,
+        profileName: args.profileName,
+      })
+    })
 
     task(
       `open:shell:${stage}`,
@@ -49,16 +52,19 @@ export default ({ proj, stages, region }: IOptions) => {
     const stage = 'dev'
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(
-      `add:aws-vault:${stage}`, () => {
-        const args = parseArgs(
-        globalArgs
-          .option('profile-name', {
-            type: 'string',
-          })
-        )
-        addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
-      }
-    )
+    task(`add:aws-vault:${stage}`, async () => {
+      const args = parseArgs(
+        globalArgs.option('profile-name', {
+          type: 'string',
+        }),
+      )
+      addAwsVaultProfile({
+        proj,
+        stage,
+        region,
+        roleName: userRoleName,
+        profileName: args.profileName,
+      })
+    })
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -22,19 +22,21 @@ export default ({ proj, stages, region }: IOptions) => {
   stages.forEach((stage) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, async () => {
+    task(`add:aws-vault:${stage}`, (done) => {
       const args = parseArgs(
         globalArgs.option('profile-name', {
           type: 'string',
         }),
       )
-      await addAwsVaultProfile({
+      addAwsVaultProfile({
         proj,
         stage,
         region,
         roleName: userRoleName,
         profileName: args.profileName,
       })
+
+      done()
     })
 
     task(
@@ -52,19 +54,20 @@ export default ({ proj, stages, region }: IOptions) => {
     const stage = 'dev'
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, async () => {
+    task(`add:aws-vault:${stage}`, (done) => {
       const args = parseArgs(
         globalArgs.option('profile-name', {
           type: 'string',
         }),
       )
-      await addAwsVaultProfile({
+      addAwsVaultProfile({
         proj,
         stage,
         region,
         roleName: userRoleName,
         profileName: args.profileName,
       })
+      done()
     })
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -22,20 +22,17 @@ export default ({ proj, stages, region }: IOptions) => {
   stages.forEach((stage) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, async () => {
-      const args = parseArgs(
-        globalArgs.option('profile-name', {
-          type: 'string',
-        }),
-      )
-      addAwsVaultProfile({
-        proj,
-        stage,
-        region,
-        roleName: userRoleName,
-        profileName: args.profileName,
-      })
-    })
+    task(
+      `add:aws-vault:${stage}`, () => {
+          const args = parseArgs(
+            globalArgs
+              .option('profile-name', {
+                type: 'string',
+              })
+          )
+          addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
+        }
+    )
 
     task(
       `open:shell:${stage}`,
@@ -52,19 +49,16 @@ export default ({ proj, stages, region }: IOptions) => {
     const stage = 'dev'
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, async () => {
-      const args = parseArgs(
-        globalArgs.option('profile-name', {
-          type: 'string',
-        }),
-      )
-      addAwsVaultProfile({
-        proj,
-        stage,
-        region,
-        roleName: userRoleName,
-        profileName: args.profileName,
-      })
-    })
+    task(
+      `add:aws-vault:${stage}`, () => {
+        const args = parseArgs(
+        globalArgs
+          .option('profile-name', {
+            type: 'string',
+          })
+        )
+        addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
+      }
+    )
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -28,7 +28,7 @@ export default ({ proj, stages, region }: IOptions) => {
           type: 'string',
         }),
       )
-      addAwsVaultProfile({
+      await addAwsVaultProfile({
         proj,
         stage,
         region,
@@ -58,7 +58,7 @@ export default ({ proj, stages, region }: IOptions) => {
           type: 'string',
         }),
       )
-      addAwsVaultProfile({
+      await addAwsVaultProfile({
         proj,
         stage,
         region,

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -22,21 +22,19 @@ export default ({ proj, stages, region }: IOptions) => {
   stages.forEach((stage) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, (done) => {
+    task(`add:aws-vault:${stage}`, async () => {
       const args = parseArgs(
         globalArgs.option('profile-name', {
           type: 'string',
         }),
       )
-      addAwsVaultProfile({
+      await addAwsVaultProfile({
         proj,
         stage,
         region,
         roleName: userRoleName,
         profileName: args.profileName,
       })
-
-      done()
     })
 
     task(
@@ -54,20 +52,19 @@ export default ({ proj, stages, region }: IOptions) => {
     const stage = 'dev'
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
-    task(`add:aws-vault:${stage}`, (done) => {
+    task(`add:aws-vault:${stage}`, async () => {
       const args = parseArgs(
         globalArgs.option('profile-name', {
           type: 'string',
         }),
       )
-      addAwsVaultProfile({
+      await addAwsVaultProfile({
         proj,
         stage,
         region,
         roleName: userRoleName,
         profileName: args.profileName,
       })
-      done()
     })
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -34,7 +34,7 @@ export default ({ proj, stages, region }: IOptions) => {
         region,
         roleName: userRoleName,
         profileName: args.profileName,
-      })
+      })()
     })
 
     task(
@@ -64,7 +64,7 @@ export default ({ proj, stages, region }: IOptions) => {
         region,
         roleName: userRoleName,
         profileName: args.profileName,
-      })
+      })()
     })
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -6,6 +6,7 @@ import { toCopy } from './colors'
 import { userRoleName } from './userRoleName'
 import openAwsConsoleTask from './internal/openAwsConsoleTask'
 import { openManagedInstanceShellTask } from './internal/openManagedInstanceShellTask'
+import { globalArgs, parseArgs } from './internal/args'
 
 interface IOptions {
   proj: string
@@ -22,8 +23,15 @@ export default ({ proj, stages, region }: IOptions) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
     task(
-      `add:aws-vault:${stage}`,
-      addAwsVaultProfile({ proj, stage, region, roleName: userRoleName }),
+      `add:aws-vault:${stage}`, () => {
+          const args = parseArgs(
+            globalArgs
+              .option('profile-name', {
+                type: 'string',
+              })
+          )
+          addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName })
+        }
     )
 
     task(
@@ -42,8 +50,16 @@ export default ({ proj, stages, region }: IOptions) => {
     task(`open:aws:${stage}`, openAwsConsoleTask({ proj, stage, region }))
 
     task(
-      `add:aws-vault:${stage}`,
-      addAwsVaultProfile({ proj, stage, region, roleName: userRoleName }),
+      `add:aws-vault:${stage}`, () => {
+        const args = parseArgs(
+        globalArgs
+          .option('profile-name', {
+            type: 'string',
+          })
+        )
+
+        addAwsVaultProfile({ proj, stage, region, roleName: userRoleName, profileName: args.profileName }),
+      }
     )
   }
 }

--- a/src/opsUserGulpTasks.ts
+++ b/src/opsUserGulpTasks.ts
@@ -24,15 +24,19 @@ export default ({ proj, stages, region }: IOptions) => {
 
     task(`add:aws-vault:${stage}`, async () => {
       const args = parseArgs(
-        globalArgs.option('profile-name', {
-          type: 'string',
-        }),
+        globalArgs
+          .option('profile-name', {
+            type: 'string',
+          })
+          .option('role-name', {
+            type: 'string',
+          }),
       )
       await addAwsVaultProfile({
         proj,
         stage,
         region,
-        roleName: userRoleName,
+        roleName: args.roleName ?? userRoleName,
         profileName: args.profileName,
       })()
     })
@@ -54,15 +58,19 @@ export default ({ proj, stages, region }: IOptions) => {
 
     task(`add:aws-vault:${stage}`, async () => {
       const args = parseArgs(
-        globalArgs.option('profile-name', {
-          type: 'string',
-        }),
+        globalArgs
+          .option('profile-name', {
+            type: 'string',
+          })
+          .option('role-name', {
+            type: 'string',
+          }),
       )
       await addAwsVaultProfile({
         proj,
         stage,
         region,
-        roleName: userRoleName,
+        roleName: args.roleName ?? userRoleName,
         profileName: args.profileName,
       })()
     })


### PR DESCRIPTION
Allows overwriting of default profile name to keep inline with current usage.

Making roleName non default meant that the profileName would include the role which would break current users workflows, e.g `aws-vault exec tannery` would become `aws-vault exec tannery-ops`